### PR TITLE
Filter out None points when calculating RTT

### DIFF
--- a/tcp_latency/tcp_latency.py
+++ b/tcp_latency/tcp_latency.py
@@ -76,6 +76,8 @@ def measure_latency(
         last_latency_point = latency_point(
             host=host, port=port, timeout=timeout,
         )
+        latency_points.append(last_latency_point)
+
         if human_output:
             if i == 0:
                 print('tcp-latency {}'.format(host))
@@ -91,8 +93,6 @@ def measure_latency(
                     print(
                         f'rtt min/avg/max = {min(received_points)}/{mean(received_points)}/{max(received_points)} ms',   # noqa: E501
                     )
-
-        latency_points.append(last_latency_point)
 
     return latency_points
 

--- a/tcp_latency/tcp_latency.py
+++ b/tcp_latency/tcp_latency.py
@@ -86,9 +86,10 @@ def measure_latency(
             if i == len(range(runs))-1:
                 print(f'--- {host} tcp-latency statistics ---')
                 print(f'{i+1} packets transmitted')
-                if latency_points:
+                received_points = [point for point in latency_points if point]
+                if received_points:
                     print(
-                        f'rtt min/avg/max = {min(latency_points)}/{mean(latency_points)}/{max(latency_points)} ms',   # noqa: E501
+                        f'rtt min/avg/max = {min(received_points)}/{mean(received_points)}/{max(received_points)} ms',   # noqa: E501
                     )
 
         latency_points.append(last_latency_point)


### PR DESCRIPTION
Fix dgzlopes/tcp-latency#14

***

Filter's out the `None` points from `latency_points` to prevent the `min`, `mean`, and `max` from receiving any `None` values and throwing an error.

If preferred, I could use `filter()` over the list comprehension I used:
```python
received_points = list(filter(bool, latency_points))
```