### PR TITLE
Add transmitted vs received statistics

### DIFF
--- a/tcp_latency/tcp_latency.py
+++ b/tcp_latency/tcp_latency.py
@@ -76,6 +76,9 @@ def measure_latency(
         last_latency_point = latency_point(
             host=host, port=port, timeout=timeout,
         )
+
+        latency_points.append(last_latency_point)
+
         if human_output:
             if i == 0:
                 print('tcp-latency {}'.format(host))
@@ -85,13 +88,13 @@ def measure_latency(
             )
             if i == len(range(runs))-1:
                 print(f'--- {host} tcp-latency statistics ---')
-                print(f'{i+1} packets transmitted')
-                if latency_points:
+                statistics = generate_statistics(latency_points)
+                print(statistics)
+                times = [point for point in latency_points if point]
+                if times:
                     print(
-                        f'rtt min/avg/max = {min(latency_points)}/{mean(latency_points)}/{max(latency_points)} ms',   # noqa: E501
+                        f'rtt min/avg/max = {min(times, default=0)}/{mean(times)}/{max(times, default=0)} ms',   # noqa: E501
                     )
-
-        latency_points.append(last_latency_point)
 
     return latency_points
 
@@ -136,6 +139,21 @@ def _human_output(host: str, port: int, timeout: int, latency_point: float, seq_
         )
     else:
         print(f'{host}: tcp seq={seq_number} port={port} timeout={timeout} failed')
+
+
+def generate_statistics(latency_point_list):
+    """ Build the statistics string
+
+    Args:
+        latency_point_list: list of latency points
+    Returns:
+        A string indicating some metrics of the latency points
+    """
+    transmitted = len(latency_point_list)
+    received = len([point for point in latency_point_list if point])
+    loss = 100 - (received / transmitted * 100)
+
+    return f'{transmitted} packets transmitted, {received} packets received, {loss}% packet loss'
 
 
 def _main():

--- a/tcp_latency/tcp_latency.py
+++ b/tcp_latency/tcp_latency.py
@@ -93,7 +93,7 @@ def measure_latency(
                 times = [point for point in latency_points if point]
                 if times:
                     print(
-                        f'rtt min/avg/max = {min(times, default=0)}/{mean(times)}/{max(times, default=0)} ms',   # noqa: E501
+                        f'rtt min/avg/max = {min(times)}/{mean(times)}/{max(times)} ms',   # noqa: E501
                     )
 
     return latency_points

--- a/tests/tcp_latency_test.py
+++ b/tests/tcp_latency_test.py
@@ -32,9 +32,26 @@ def test_tcpLatency_valid_list_return():
         assert isinstance(element, float) or None
 
 
-def test_statistics():
+def test_generate_statistics():
     latency_points = [1.0, None, 1.0, 1.0, None]
 
     statistics_string = generate_statistics(latency_points)
 
     assert statistics_string == '5 packets transmitted, 3 packets received, 40.0% packet loss'
+
+
+def test_generate_statistics_with_100_loss():
+    latency_points = [None, None, None, None, None]
+
+    statistics_string = generate_statistics(latency_points)
+
+    assert statistics_string == '5 packets transmitted, 0 packets received, 100.0% packet loss'
+
+
+def test_generate_statistics_with_0_loss():
+    latency_points = [1.0, 2.0, 3.0, 4.0, 5.0]
+
+    statistics_string = generate_statistics(latency_points)
+
+    assert statistics_string == '5 packets transmitted, 5 packets received, 0.0% packet loss'
+

--- a/tests/tcp_latency_test.py
+++ b/tests/tcp_latency_test.py
@@ -1,5 +1,4 @@
-from tcp_latency import latency_point
-from tcp_latency import measure_latency
+from tcp_latency import latency_point, measure_latency, generate_statistics
 
 
 def test_latencyPoint_unreachable_host():
@@ -31,3 +30,11 @@ def test_tcpLatency_valid_list_return():
 
     for element in latency_run:
         assert isinstance(element, float) or None
+
+
+def test_statistics():
+    latency_points = [1.0, None, 1.0, 1.0, None]
+
+    statistics_string = generate_statistics(latency_points)
+
+    assert statistics_string == '5 packets transmitted, 3 packets received, 40.0% packet loss'


### PR DESCRIPTION
Solves #5 

Example output:
<img width="539" alt="Screen Shot 2020-10-01 at 17 06 33" src="https://user-images.githubusercontent.com/12943780/94871925-7a1e7d00-0408-11eb-96d0-f237265e22e1.png">

Also, there was a bug where the points were appended, the last one wasn't taken into account that's why I moved the line:
`latency_points.append(last_latency_point)`
Before reporting the statistics.
