### PR TITLE
Gracefully handle transmission errors with better error message

### DIFF
--- a/tcp_latency/tcp_latency.py
+++ b/tcp_latency/tcp_latency.py
@@ -85,13 +85,16 @@ def measure_latency(
             )
             if i == len(range(runs))-1:
                 print(f'--- {host} tcp-latency statistics ---')
-                print(f'{i+1} packets transmitted')
                 if latency_points:
+                    print(f'{len(latency_points)} out of {i+1} packets transmitted successfully')
                     print(
                         f'rtt min/avg/max = {min(latency_points)}/{mean(latency_points)}/{max(latency_points)} ms',   # noqa: E501
                     )
+                else:
+                    print(f'All {runs} transmissions failed')
 
-        latency_points.append(last_latency_point)
+        if last_latency_point is not None:
+            latency_points.append(last_latency_point)
 
     return latency_points
 


### PR DESCRIPTION
I encountered the following error while measuring latency:
```
tcp-latency https://active.illinois.edu/
https://active.illinois.edu/: tcp seq=0 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=1 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=2 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=3 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=4 port=443 timeout=5 failed
--- https://active.illinois.edu/ tcp-latency statistics ---
5 packets transmitted
Traceback (most recent call last):
  File "/usr/local/bin/tcp-latency", line 8, in <module>
    sys.exit(_main())
  File "/usr/local/lib/python3.9/site-packages/tcp_latency/tcp_latency.py", line 143, in _main
    measure_latency(
  File "/usr/local/lib/python3.9/site-packages/tcp_latency/tcp_latency.py", line 91, in measure_latency
    f'rtt min/avg/max = {min(latency_points)}/{mean(latency_points)}/{max(latency_points)} ms',   # noqa: E501
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

The main issue seems to be that we are not handling transmission errors robustly.
This PR adds a small change to cover such cases, so that we have output like:

```
tcp-latency https://active.illinois.edu/
https://active.illinois.edu/: tcp seq=0 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=1 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=2 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=3 port=443 timeout=5 failed
https://active.illinois.edu/: tcp seq=4 port=443 timeout=5 failed
--- https://active.illinois.edu/ tcp-latency statistics ---
All 5 transmissions failed
```