### PR TITLE
Added IPv6 support

### DIFF
--- a/tcp_latency/tcp_latency.py
+++ b/tcp_latency/tcp_latency.py
@@ -107,7 +107,10 @@ def latency_point(host: str, port: int = 443, timeout: float = 5) -> Optional[fl
     Calculate a latency point using sockets. If something bad happens the point returned is None
     '''
     # New Socket and Time out
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if(socket.has_dualstack_ipv6()):
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    else:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(timeout)
 
     # Start a timer


### PR DESCRIPTION
Added IPv6 support.

In the event that the host environment supports dual stack, then AF_INET6 will be used, which supports both v4 and v6. If the host is not dual stack friendly then AF_INET will be used as a fallback.